### PR TITLE
Add baseline lead discovery agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,28 @@ Pour commencer à utiliser Mon ShipFast, suivez ces étapes :
 ## Licence
 
 Ce projet est sous licence MIT. Voir le fichier `LICENSE` pour plus de détails.
+
+## Agent IA pour la génération de leads
+
+Un agent Python minimal est fourni pour prioriser des leads en fonction de mots-clés et de filtres (industrie, pays, taille). Il s'appuie sur un scoring rapide par similarité de mots, prêt à être remplacé par un reranking LLM.
+
+### Structure
+- `agent/config.py` : configuration de l'agent et filtres.
+- `agent/models.py` : modèle de données `Lead`.
+- `agent/data_sources.py` : sources de données (JSON local, mémoire, composite).
+- `agent/ranking.py` : scoring par tokens et reranking.
+- `agent/lead_agent.py` : orchestration filtre + déduplication + reranking.
+- `main.py` : CLI pour tester avec un jeu d'exemples.
+
+### Jeu de données d'exemple
+`data/leads.json` contient quelques sociétés fictives pour tester le flux localement.
+
+### Exécution rapide
+```bash
+python main.py "outbound IA" --industries Marketing --countries France --limit 3
+```
+
+### Tests
+```bash
+pytest
+```

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+
+@dataclass
+class LeadFilter:
+    """Selection rules for filtering generated leads.
+
+    Attributes:
+        industries: Optional list of industry names to keep (case-insensitive).
+        countries: Optional list of target countries or regions.
+        min_employee_count: Minimum company size to keep, if known.
+        max_employee_count: Maximum company size to keep, if known.
+    """
+
+    industries: Optional[Sequence[str]] = None
+    countries: Optional[Sequence[str]] = None
+    min_employee_count: Optional[int] = None
+    max_employee_count: Optional[int] = None
+
+
+@dataclass
+class AgentSettings:
+    """Top-level configuration for the lead discovery agent."""
+
+    keywords: Sequence[str]
+    filter: LeadFilter = field(default_factory=LeadFilter)
+    limit: int = 20
+    dedupe: bool = True
+    llm_model: Optional[str] = None
+    embedding_model: Optional[str] = None
+    openai_api_key: Optional[str] = None
+
+    def normalized_keywords(self) -> List[str]:
+        return [kw.strip().lower() for kw in self.keywords if kw.strip()]

--- a/agent/data_sources.py
+++ b/agent/data_sources.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+from .models import Lead
+
+
+class LeadSource:
+    """Interface for all lead providers."""
+
+    def fetch(self) -> Iterable[Lead]:
+        raise NotImplementedError
+
+
+class LocalJSONSource(LeadSource):
+    """Reads leads from a JSON file for fast iteration and offline testing."""
+
+    def __init__(self, path: Path):
+        self.path = path
+
+    def fetch(self) -> Iterable[Lead]:
+        if not self.path.exists():
+            return []
+        with self.path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        for entry in data:
+            yield Lead(**entry)
+
+
+class CompositeSource(LeadSource):
+    """Aggregates multiple sources as a single iterator."""
+
+    def __init__(self, sources: Sequence[LeadSource]):
+        self.sources = sources
+
+    def fetch(self) -> Iterable[Lead]:
+        for source in self.sources:
+            yield from source.fetch()
+
+
+class MemorySource(LeadSource):
+    """In-memory source for synthetic or test data."""
+
+    def __init__(self, leads: List[Lead]):
+        self.leads = leads
+
+    def fetch(self) -> Iterable[Lead]:
+        return list(self.leads)

--- a/agent/lead_agent.py
+++ b/agent/lead_agent.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List
+
+from .config import AgentSettings
+from .data_sources import LeadSource
+from .models import Lead
+from .ranking import rerank
+
+logger = logging.getLogger(__name__)
+
+
+def _apply_filter(leads: Iterable[Lead], settings: AgentSettings) -> Iterable[Lead]:
+    for lead in leads:
+        if settings.filter.industries:
+            if not lead.industry or lead.industry.lower() not in [i.lower() for i in settings.filter.industries]:
+                continue
+        if settings.filter.countries:
+            if not lead.country or lead.country.lower() not in [c.lower() for c in settings.filter.countries]:
+                continue
+        if settings.filter.min_employee_count and lead.employee_count:
+            if lead.employee_count < settings.filter.min_employee_count:
+                continue
+        if settings.filter.max_employee_count and lead.employee_count:
+            if lead.employee_count > settings.filter.max_employee_count:
+                continue
+        yield lead
+
+
+def _deduplicate(leads: Iterable[Lead]) -> List[Lead]:
+    seen = set()
+    unique: List[Lead] = []
+    for lead in leads:
+        key = lead.name.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(lead)
+    return unique
+
+
+def discover_leads(source: LeadSource, settings: AgentSettings) -> List[Lead]:
+    """Discover and rerank leads from the provided source.
+
+    The function is intentionally modular: keyword-based scoring is used as a
+    baseline, and you can later insert an LLM reranking stage by swapping the
+    ``rerank`` implementation.
+    """
+
+    raw_leads = source.fetch()
+    filtered = _apply_filter(raw_leads, settings)
+    if settings.dedupe:
+        filtered = _deduplicate(filtered)
+    scored = rerank(filtered, settings.normalized_keywords(), settings.limit)
+    logger.info("Found %d relevant leads", len(scored))
+    return [lead for lead, _ in scored]

--- a/agent/lead_agent.py
+++ b/agent/lead_agent.py
@@ -22,10 +22,10 @@ def _apply_filter(leads: Iterable[Lead], settings: AgentSettings) -> Iterable[Le
         if lower_countries:
             if not lead.country or lead.country.lower() not in lower_countries:
                 continue
-        if settings.filter.min_employee_count and lead.employee_count:
+        if settings.filter.min_employee_count is not None and lead.employee_count is not None:
             if lead.employee_count < settings.filter.min_employee_count:
                 continue
-        if settings.filter.max_employee_count and lead.employee_count:
+        if settings.filter.max_employee_count is not None and lead.employee_count is not None:
             if lead.employee_count > settings.filter.max_employee_count:
                 continue
         yield lead

--- a/agent/lead_agent.py
+++ b/agent/lead_agent.py
@@ -12,9 +12,10 @@ logger = logging.getLogger(__name__)
 
 
 def _apply_filter(leads: Iterable[Lead], settings: AgentSettings) -> Iterable[Lead]:
+    lower_industries = [i.lower() for i in settings.filter.industries] if settings.filter.industries else []
     for lead in leads:
         if settings.filter.industries:
-            if not lead.industry or lead.industry.lower() not in [i.lower() for i in settings.filter.industries]:
+            if not lead.industry or lead.industry.lower() not in lower_industries:
                 continue
         if settings.filter.countries:
             if not lead.country or lead.country.lower() not in [c.lower() for c in settings.filter.countries]:

--- a/agent/lead_agent.py
+++ b/agent/lead_agent.py
@@ -13,12 +13,14 @@ logger = logging.getLogger(__name__)
 
 def _apply_filter(leads: Iterable[Lead], settings: AgentSettings) -> Iterable[Lead]:
     lower_industries = [i.lower() for i in settings.filter.industries] if settings.filter.industries else []
+    lower_industries = [i.lower() for i in settings.filter.industries] if settings.filter.industries else None
+    lower_countries = [c.lower() for c in settings.filter.countries] if settings.filter.countries else None
     for lead in leads:
-        if settings.filter.industries:
+        if lower_industries:
             if not lead.industry or lead.industry.lower() not in lower_industries:
                 continue
-        if settings.filter.countries:
-            if not lead.country or lead.country.lower() not in [c.lower() for c in settings.filter.countries]:
+        if lower_countries:
+            if not lead.country or lead.country.lower() not in lower_countries:
                 continue
         if settings.filter.min_employee_count and lead.employee_count:
             if lead.employee_count < settings.filter.min_employee_count:

--- a/agent/models.py
+++ b/agent/models.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Lead:
+    """Representation of a potential lead or company."""
+
+    name: str
+    industry: Optional[str] = None
+    country: Optional[str] = None
+    employee_count: Optional[int] = None
+    description: Optional[str] = None
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def normalized_tokens(self) -> List[str]:
+        tokens = []
+        for field_value in (self.name, self.industry, self.description):
+            if not field_value:
+                continue
+            tokens.extend(field_value.lower().split())
+        return tokens

--- a/agent/ranking.py
+++ b/agent/ranking.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Iterable, List, Sequence, Tuple
+
+from .models import Lead
+
+
+def _tokenize_keywords(keywords: Sequence[str]) -> List[str]:
+    tokens: List[str] = []
+    for kw in keywords:
+        kw = kw.lower().strip()
+        if not kw:
+            continue
+        tokens.extend(kw.split())
+    return tokens
+
+
+def keyword_score(lead: Lead, keywords: Sequence[str]) -> float:
+    """Compute a simple relevance score using token overlap.
+
+    The scoring is cosine similarity between keyword tokens and lead tokens,
+    which provides a fast, dependency-free baseline. External LLM reranking can
+    be layered on top of this score later.
+    """
+
+    keyword_tokens = _tokenize_keywords(keywords)
+    lead_tokens = lead.normalized_tokens()
+    if not keyword_tokens or not lead_tokens:
+        return 0.0
+
+    keyword_counter = Counter(keyword_tokens)
+    lead_counter = Counter(lead_tokens)
+
+    dot_product = sum(keyword_counter[t] * lead_counter[t] for t in keyword_counter)
+    if dot_product == 0:
+        return 0.0
+
+    keyword_norm = math.sqrt(sum(v * v for v in keyword_counter.values()))
+    lead_norm = math.sqrt(sum(v * v for v in lead_counter.values()))
+    if keyword_norm == 0 or lead_norm == 0:
+        return 0.0
+    return dot_product / (keyword_norm * lead_norm)
+
+
+def rerank(leads: Iterable[Lead], keywords: Sequence[str], limit: int) -> List[Tuple[Lead, float]]:
+    scored: List[Tuple[Lead, float]] = []
+    for lead in leads:
+        score = keyword_score(lead, keywords)
+        if score == 0:
+            continue
+        scored.append((lead, score))
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return scored[:limit]

--- a/data/leads.json
+++ b/data/leads.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "OutboundBoost",
+    "industry": "Marketing",
+    "country": "France",
+    "employee_count": 35,
+    "description": "IA outbound pour les sales teams B2B"
+  },
+  {
+    "name": "DataPilot",
+    "industry": "Analytics",
+    "country": "Canada",
+    "employee_count": 80,
+    "description": "Collecte de signaux commerciaux et scoring prédictif"
+  },
+  {
+    "name": "GrowthForge",
+    "industry": "Marketing",
+    "country": "USA",
+    "employee_count": 20,
+    "description": "Automatisation du cold email alimentée par GPT"
+  },
+  {
+    "name": "FinTrack",
+    "industry": "Fintech",
+    "country": "France",
+    "employee_count": 120,
+    "description": "Outils de conformité et KYC pour banques digitales"
+  },
+  {
+    "name": "EcoSupply",
+    "industry": "Supply Chain",
+    "country": "Germany",
+    "employee_count": 55,
+    "description": "Optimisation des achats industriels via IA"
+  }
+]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import List
+
+from agent.config import AgentSettings, LeadFilter
+from agent.data_sources import CompositeSource, LocalJSONSource
+from agent.lead_agent import discover_leads
+
+logging.basicConfig(level=logging.INFO)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Lead discovery agent (local baseline)")
+    parser.add_argument("keywords", nargs="+", help="Keywords describing your ideal lead")
+    parser.add_argument("--data", default="data/leads.json", help="Path to a JSON file of leads")
+    parser.add_argument("--industries", nargs="*", help="Restrict to these industries")
+    parser.add_argument("--countries", nargs="*", help="Restrict to these countries")
+    parser.add_argument("--limit", type=int, default=10, help="Maximum number of leads to return")
+    return parser.parse_args()
+
+
+def build_settings(args: argparse.Namespace) -> AgentSettings:
+    lead_filter = LeadFilter(
+        industries=args.industries or None,
+        countries=args.countries or None,
+    )
+    return AgentSettings(
+        keywords=args.keywords,
+        filter=lead_filter,
+        limit=args.limit,
+    )
+
+
+def run() -> List[str]:
+    args = parse_args()
+    settings = build_settings(args)
+    source = CompositeSource([LocalJSONSource(Path(args.data))])
+    leads = discover_leads(source, settings)
+    for lead in leads:
+        print(f"- {lead.name} ({lead.industry or 'n/a'}) - {lead.description or 'No description'}")
+    return [lead.name for lead in leads]
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,19 @@
+from agent.config import AgentSettings, LeadFilter
+from agent.data_sources import MemorySource
+from agent.lead_agent import discover_leads
+from agent.models import Lead
+
+
+def test_discover_leads_filters_and_ranks():
+    leads = [
+        Lead(name="Alpha", industry="Marketing", description="outbound ia"),
+        Lead(name="Beta", industry="Fintech", description="payments"),
+        Lead(name="Gamma", industry="Marketing", description="growth outbound ia"),
+    ]
+    source = MemorySource(leads)
+    settings = AgentSettings(keywords=["outbound", "ia"], filter=LeadFilter(industries=["Marketing"]), limit=2)
+
+    results = discover_leads(source, settings)
+
+    assert [lead.name for lead in results] == ["Alpha", "Gamma"]
+    assert len(results) == 2


### PR DESCRIPTION
## Summary
- add modular Python agent for lead discovery with keyword scoring and filtering
- provide sample local JSON dataset and CLI entrypoint for quick testing
- include pytest coverage for ranking and filtering logic

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692963ca4d84832eb141f14c7b8d0fef)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a modular Python lead discovery agent with keyword-based ranking, filtering, a CLI, sample JSON data, and pytest coverage.
> 
> - **Agent (Python)**:
>   - Add modular lead discovery pipeline: `agent/models.py` (`Lead`), `agent/config.py` (`AgentSettings`, `LeadFilter`), `agent/data_sources.py` (local JSON, memory, composite sources), `agent/ranking.py` (token-based cosine scoring + rerank), `agent/lead_agent.py` (filtering, optional dedupe, rerank orchestration).
> - **CLI**:
>   - `main.py` provides argument parsing, builds settings, reads from `data/leads.json`, prints top leads.
> - **Data**:
>   - Add sample dataset `data/leads.json` for local testing.
> - **Tests**:
>   - Add pytest setup `tests/conftest.py` and unit test `tests/test_ranking.py` covering filtering and ranking.
> - **Docs**:
>   - Update `README.md` with agent overview, structure, quick start, dataset, and test instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5060b4595f0b3c9c8a63075d61a23660508408a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->